### PR TITLE
feat: add markdownlint hook and clean up config

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -9,3 +9,4 @@
 !agents
 !rules
 !skills
+!hooks

--- a/.claude/hooks/lint-markdown.sh
+++ b/.claude/hooks/lint-markdown.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# stdin から JSON を読み取り、file_path を取得
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+# .md 以外は何もしない
+[[ "$file_path" != *.md ]] && exit 0
+
+# ファイルが存在しない場合も何もしない
+[[ ! -f "$file_path" ]] && exit 0
+
+# markdownlint-cli2 を実行（--no-globs で設定ファイルの globs を無視）
+output=$(markdownlint-cli2 --config "$HOME/.config/markdown-cli2/.markdownlint-cli2.jsonc" --no-globs "$file_path" 2>&1)
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+  # exit code 2 + stderr → Claude Code にエラーをフィードバック
+  echo "$output" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,6 +106,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/lint-markdown.sh",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/.config/.gitignore
+++ b/.config/.gitignore
@@ -3,10 +3,17 @@
 
 # Whitelist specific directories and files
 !git/
+!git/**
 !tmux/
+!tmux/**
 !nvim/
+!nvim/**
 !zsh/
+!zsh/**
 !.gitignore
 !ccstatusline/
 !ccstatusline/settings.json
+!gh/
 !gh/config.yml
+!markdown-cli2/
+!markdown-cli2/.markdownlint-cli2.jsonc

--- a/.config/gh/config.yml
+++ b/.config/gh/config.yml
@@ -1,0 +1,27 @@
+# The current version of the config schema
+version: 1
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: https
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor:
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# Preference for editor-based interactive prompting. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prefer_editor_prompt: disabled
+# A pager program to send command output to, e.g. "less". If blank, will refer to environment. Set the value to "cat" to disable the pager.
+pager:
+# Aliases allow you to create nicknames for gh commands
+aliases:
+    co: pr checkout
+# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+http_unix_socket:
+# What web browser gh should use when opening URLs. If blank, will refer to environment.
+browser:
+# Whether to display labels using their RGB hex color codes in terminals that support truecolor. Supported values: enabled, disabled
+color_labels: disabled
+# Whether customizable, 4-bit accessible colors should be used. Supported values: enabled, disabled
+accessible_colors: disabled
+# Whether an accessible prompter should be used. Supported values: enabled, disabled
+accessible_prompter: disabled
+# Whether to use a animated spinner as a progress indicator. If disabled, a textual progress indicator is used instead. Supported values: enabled, disabled
+spinner: enabled

--- a/.config/markdown-cli2/.markdownlint-cli2.jsonc
+++ b/.config/markdown-cli2/.markdownlint-cli2.jsonc
@@ -1,30 +1,22 @@
 {
-  // markdownlint 本体のルール設定
   "config": {
-    // 見出しレベルの飛びを許可
+    // Allow skipping heading levels
     "MD001": false,
 
-    // 行長制限はしない（日本語Markdownあるある）
+    // Disable line length limit for Japanese content
     "MD013": false,
 
-    // 強調記法はスタイル統一だけ（禁止はしない）
     "MD050": {
       "style": "consistent"
     },
 
-    // 見出し前後の空行は厳しすぎるので緩める
-    "MD022": false,
-    "MD032": false
-  },
+    // Allow duplicate headings under different parents
+    "MD024": { "siblings_only": true },
 
-  // lint 対象
-  "globs": [
-    "**/*.md"
-  ],
+    // Disable to avoid false positives with front matter
+    "MD041": false,
 
-  // 無視したいファイル
-  "ignores": [
-    "node_modules/**",
-    "dist/**"
-  ]
+    // Enforce backtick style for code fences
+    "MD048": { "style": "backtick" }
+  }
 }

--- a/.config/markdown-cli2/.markdownlint-cli2.jsonc
+++ b/.config/markdown-cli2/.markdownlint-cli2.jsonc
@@ -1,0 +1,30 @@
+{
+  // markdownlint 本体のルール設定
+  "config": {
+    // 見出しレベルの飛びを許可
+    "MD001": false,
+
+    // 行長制限はしない（日本語Markdownあるある）
+    "MD013": false,
+
+    // 強調記法はスタイル統一だけ（禁止はしない）
+    "MD050": {
+      "style": "consistent"
+    },
+
+    // 見出し前後の空行は厳しすぎるので緩める
+    "MD022": false,
+    "MD032": false
+  },
+
+  // lint 対象
+  "globs": [
+    "**/*.md"
+  ],
+
+  // 無視したいファイル
+  "ignores": [
+    "node_modules/**",
+    "dist/**"
+  ]
+}

--- a/.config/zsh/localbin.zsh
+++ b/.config/zsh/localbin.zsh
@@ -1,0 +1,3 @@
+if [[ -d "$HOME/.local/bin" ]] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -18,6 +18,7 @@
       - node
       - gh
       - ripgrep
+      - markdownlint-cli2
 
     homebrew_cask_packages:
       - font-plemol-jp


### PR DESCRIPTION
## Summary
- Add PostToolUse hook to run markdownlint-cli2 on .md files after Edit/Write/MultiEdit
- Clean up markdownlint-cli2 config: remove unused globs/ignores, add MD024/MD048 rules
- Add gh/zsh configs and fix gitignore whitelist

## Test plan
- [ ] Verify markdown lint hook triggers on .md file edits
- [ ] Confirm markdownlint rules (MD024, MD048) work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)