### PR TITLE
fix: skip markdown lint for plan files

### DIFF
--- a/.claude/hooks/lint-markdown.sh
+++ b/.claude/hooks/lint-markdown.sh
@@ -9,6 +9,9 @@ file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
 # ファイルが存在しない場合も何もしない
 [[ ! -f "$file_path" ]] && exit 0
 
+# plan file は lint をスキップ
+[[ "$file_path" == */.claude/plans/*.md ]] && exit 0
+
 # markdownlint-cli2 を実行（--no-globs で設定ファイルの globs を無視）
 output=$(markdownlint-cli2 --config "$HOME/.config/markdown-cli2/.markdownlint-cli2.jsonc" --no-globs "$file_path" 2>&1)
 exit_code=$?


### PR DESCRIPTION
## Summary

- Plan file（`.claude/plans/*.md`）に対する markdownlint の実行をスキップする条件を追加

## Test plan

- [ ] plan file を編集し、lint hook が発火しないことを確認
- [ ] 通常の `.md` ファイルを編集し、lint hook が従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)