### PR TITLE
feat: add hook to open plan files in VS Code after creation

### DIFF
--- a/.claude/hooks/open-plan-vscode.sh
+++ b/.claude/hooks/open-plan-vscode.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# プランファイルが作成・更新されたら VS Code で開く
+
+# stdin から JSON を読み取り、file_path を取得
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+# file_path がなければ何もしない
+[[ -z "$file_path" ]] && exit 0
+
+# .claude/plans/ 配下の .md ファイルのみ対象
+[[ "$file_path" != */.claude/plans/*.md ]] && exit 0
+
+# ファイルが存在しない場合も何もしない
+[[ ! -f "$file_path" ]] && exit 0
+
+# code コマンドが利用可能か確認
+if ! command -v code &>/dev/null; then
+  exit 0
+fi
+
+# VS Code で開く（バックグラウンドで実行、失敗しても無視）
+code "$file_path" &>/dev/null &
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,11 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/lint-markdown.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/open-plan-vscode.sh",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
PostToolUse hook that detects when plan files (.claude/plans/*.md) are
written or edited, and automatically opens them in VS Code. Gracefully
skips when the `code` command is not available.

https://claude.ai/code/session_01LhYoQsbKegjdvhj2pgLCHZ