### PR TITLE
feat: add WebSearch and WebFetch to permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,7 +77,9 @@
       "Bash(git add *)",
       "Bash(git remote *)",
       "Bash(git pull *)",
-      "Bash(git cherry-pick *)"
+      "Bash(git cherry-pick *)",
+      "WebSearch",
+      "WebFetch"
     ],
     "ask": [
       "Bash(git push *)",


### PR DESCRIPTION
## Summary

- `WebSearch` と `WebFetch` を `permissions.allow` に追加
- Web 検索・コンテンツ取得時に許可プロンプトなしで実行可能にする

## Test plan

- [ ] `WebSearch` で検索実行時に許可プロンプトが出ないことを確認
- [ ] `WebFetch` で URL 取得時に許可プロンプトが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)