### PR TITLE
fix: add brew PATH setup after Homebrew installation

### DIFF
--- a/tools/01_init.sh
+++ b/tools/01_init.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Set up brew in the current session (supports both Intel and Apple Silicon)
+eval "$(/opt/homebrew/bin/brew shellenv)" 2>/dev/null || eval "$(/usr/local/bin/brew shellenv)" 2>/dev/null
+
 brew install ansible


### PR DESCRIPTION
## Summary

- 新規 macOS 環境（特に Apple Silicon）で Homebrew インストール直後に `brew` が PATH に通っていない問題を修正
- `eval "$(brew shellenv)"` を Homebrew インストールと `brew install ansible` の間に追加
- Intel (`/usr/local`) と Apple Silicon (`/opt/homebrew`) の両方に対応

## Test plan

- [ ] `tools/01_init.sh` の内容を確認し、`eval` が Homebrew インストールと `brew install` の間に入っていることを確認
- [ ] 可能であれば新規環境（VM やコンテナ）でステップ 1 から実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)