### PR TITLE
feat(zsh): add env.zsh to set EDITOR to vim

### DIFF
--- a/.config/zsh/env.zsh
+++ b/.config/zsh/env.zsh
@@ -1,0 +1,1 @@
+export EDITOR="vim"  


### PR DESCRIPTION
## Summary
- zprezto デフォルトの `EDITOR=nano` を vim に上書きする `env.zsh` を追加
- `.zshrc` の glob ループで読み込まれる `.config/zsh/` 配下に配置

## Test plan
- [ ] 新しいシェルセッションで `echo $EDITOR` が `vim` を返すことを確認