### PR TITLE
feat(ansible): add rustup to homebrew packages

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -20,6 +20,7 @@
       - ripgrep
       - markdownlint-cli2
       - font-hackgen-nerd
+      - rustup
 
     homebrew_cask_packages:
       - font-plemol-jp


### PR DESCRIPTION
## Summary

- Add rustup to the list of homebrew packages in the Ansible playbook

## Test plan

- Run the Ansible playbook and verify rustup is installed via Homebrew