### PR TITLE
feat: add npm min-release-age supply chain protection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -170,13 +170,20 @@
     "context7@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "codex@openai-codex": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {
       "source": {
         "source": "github",
         "repo": "anthropics/claude-code"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
       }
     }
   },

--- a/.claude/skills/react-dev-guide/SKILL.md
+++ b/.claude/skills/react-dev-guide/SKILL.md
@@ -33,6 +33,10 @@ bun run test                   # テスト実行
 - `bun add xxx` でパッケージを追加しない
 - `package.json` を直接編集し、`bun install` で反映する
 
+### サプライチェーン対策
+
+- プロジェクトルートに `.npmrc` を作成し `min-release-age=7` を設定する
+
 ### 型チェック
 
 - `cd` してから `npx tsc --noEmit` を実行しない

--- a/.claude/skills/typescript-dev-guide/SKILL.md
+++ b/.claude/skills/typescript-dev-guide/SKILL.md
@@ -65,6 +65,12 @@ bun run test                   # テスト実行
 }
 ```
 
+## Rules
+
+### サプライチェーン対策
+
+- プロジェクトルートに `.npmrc` を作成し `min-release-age=7` を設定する
+
 ## Coding Conventions
 
 - 一時コメントには `TODO` / `FIXME` ラベルを使用

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary

- Add `.npmrc` with `min-release-age=7` to prevent installing npm packages released within 7 days
- Update React and TypeScript dev guide skills with project-scope `.npmrc` setup instructions
- Add openai codex plugin configuration to settings

## Test plan

- Verify `npm config list` shows `before` date derived from `min-release-age=7`
- Confirm skill files include supply chain protection guidance
