### PR TITLE
feat(codex): sync Claude skills via symlinks with CI auto-sync

### DIFF
--- a/.codex/.gitignore
+++ b/.codex/.gitignore
@@ -1,0 +1,7 @@
+# Ignore everything
+/*
+
+# Except rules
+!.gitignore
+!skills/
+skills/.system/

--- a/.codex/skills/cleanup-files
+++ b/.codex/skills/cleanup-files
@@ -1,0 +1,1 @@
+../../.claude/skills/cleanup-files

--- a/.codex/skills/commit
+++ b/.codex/skills/commit
@@ -1,0 +1,1 @@
+../../.claude/skills/commit

--- a/.codex/skills/gemini-research
+++ b/.codex/skills/gemini-research
@@ -1,0 +1,1 @@
+../../.claude/skills/gemini-research

--- a/.codex/skills/github-repo-create
+++ b/.codex/skills/github-repo-create
@@ -1,0 +1,1 @@
+../../.claude/skills/github-repo-create

--- a/.codex/skills/gpt5-prompting
+++ b/.codex/skills/gpt5-prompting
@@ -1,0 +1,1 @@
+../../.claude/skills/gpt5-prompting

--- a/.codex/skills/playwright-cli
+++ b/.codex/skills/playwright-cli
@@ -1,0 +1,1 @@
+../../.claude/skills/playwright-cli

--- a/.codex/skills/pr-merge
+++ b/.codex/skills/pr-merge
@@ -1,0 +1,1 @@
+../../.claude/skills/pr-merge

--- a/.codex/skills/python-dev-guide
+++ b/.codex/skills/python-dev-guide
@@ -1,0 +1,1 @@
+../../.claude/skills/python-dev-guide

--- a/.codex/skills/react-dev-guide
+++ b/.codex/skills/react-dev-guide
@@ -1,0 +1,1 @@
+../../.claude/skills/react-dev-guide

--- a/.codex/skills/refactor-code
+++ b/.codex/skills/refactor-code
@@ -1,0 +1,1 @@
+../../.claude/skills/refactor-code

--- a/.codex/skills/typescript-dev-guide
+++ b/.codex/skills/typescript-dev-guide
@@ -1,0 +1,1 @@
+../../.claude/skills/typescript-dev-guide

--- a/.codex/skills/update-arch
+++ b/.codex/skills/update-arch
@@ -1,0 +1,1 @@
+../../.claude/skills/update-arch

--- a/.codex/skills/update-readme
+++ b/.codex/skills/update-readme
@@ -1,0 +1,1 @@
+../../.claude/skills/update-readme

--- a/.github/workflows/sync-codex-skills.yml
+++ b/.github/workflows/sync-codex-skills.yml
@@ -1,0 +1,35 @@
+name: Sync Codex Skills
+
+on:
+  push:
+    branches: [main]
+    paths: [".claude/skills/**"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync skill symlinks
+        run: |
+          cd .codex/skills
+          for skill in ../../.claude/skills/*/; do
+            name=$(basename "$skill")
+            if [ ! -L "$name" ]; then
+              ln -sfnv "../../.claude/skills/$name" "$name"
+            fi
+          done
+
+      - name: Create PR if changes exist
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(codex): sync skill symlinks"
+          title: "chore(codex): sync skill symlinks"
+          body: |
+            `.claude/skills/` に追加されたスキルの symlink を `.codex/skills/` に同期します。
+          branch: chore/sync-codex-skills


### PR DESCRIPTION
## Summary

- add symlinks under `.codex/skills` to expose the existing Claude skills to Codex
- add `.codex/.gitignore` entries for local plugin and memory artifacts
- add a GitHub Actions workflow to keep the linked Codex skills in sync on pushes

## Test plan

- Verify each path under `.codex/skills` resolves to the corresponding skill in `.claude/skills`
- Push the branch and confirm the sync workflow runs successfully