### PR TITLE
feat(codex): add skill sync Makefile

### DIFF
--- a/.codex/.gitignore
+++ b/.codex/.gitignore
@@ -3,3 +3,4 @@
 
 # Except rules
 !.gitignore
+!Makefile

--- a/.codex/Makefile
+++ b/.codex/Makefile
@@ -1,0 +1,23 @@
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+SKILLS_SRC   := $(abspath $(MAKEFILE_DIR)../.claude/skills)
+LINK_DIR     := $(abspath $(MAKEFILE_DIR)skills)
+
+SKILL_DIRS   := $(wildcard $(SKILLS_SRC)/*)
+LINK_TARGETS := $(foreach d,$(SKILL_DIRS),$(LINK_DIR)/my-$(notdir $(d)))
+
+.PHONY: all sync clean re-sync list
+
+all: sync
+
+sync: $(LINK_TARGETS)
+
+$(LINK_DIR)/my-%: $(SKILLS_SRC)/%
+	ln -sfn $< $@
+
+clean:
+	rm -f $(LINK_DIR)/my-*
+
+re-sync: clean sync
+
+list:
+	@ls -la $(LINK_DIR) | grep -- my- || echo "(no my-* links found)"


### PR DESCRIPTION
## Summary

- add a .codex/Makefile to create and refresh my-* skill symlinks from .claude/skills
- add clean, re-sync, and list targets for local skill link management
- allow .codex/Makefile to be tracked in .codex/.gitignore

## Test plan

- not run