### PR TITLE
chore(claude): remove explicit model setting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -195,6 +195,5 @@
   },
   "alwaysThinkingEnabled": true,
   "plansDirectory": ".claude/plans",
-  "autoMemoryEnabled": false,
-  "model": "sonnet"
+  "autoMemoryEnabled": false
 }


### PR DESCRIPTION
## Summary

- remove the explicit `model` entry from Claude local settings
- keep `autoMemoryEnabled` disabled without changing other settings

## Test plan

- Not run (configuration-only change)
