### PR TITLE
feat(zsh): add Rust/Cargo environment setup

### DIFF
--- a/.config/zsh/rust.zsh
+++ b/.config/zsh/rust.zsh
@@ -1,0 +1,3 @@
+if [[ -d "$HOME/.cargo" ]] && [[ -f "$HOME/.cargo/env" ]]; then
+  . "$HOME/.cargo/env"
+fi


### PR DESCRIPTION
## Summary

- Add zsh configuration file for Rust/Cargo environment setup
- Conditionally sources `~/.cargo/env` when Cargo directory exists

## Test plan

- Verify `rust.zsh` is sourced correctly in a new shell session
- Confirm Cargo binaries are available in PATH after sourcing
