### PR TITLE
chore(claude): remove Bash(cd /*) from permission deny

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,8 +89,7 @@
       "Bash(nc *)",
       "Bash(ssh *)",
       "Bash(scp *)",
-      "Bash(sftp *)",
-      "Bash(cd /*)"
+      "Bash(sftp *)"
     ],
     "ask": [
       "Bash(git push *)",


### PR DESCRIPTION
## Summary

- Removed `Bash(cd /*)` from `permissions.deny` in `~/.claude/settings.json`.
- The rule blocked cd to any absolute path including paths inside the working repo, which pushed the assistant to use long absolute paths everywhere.
- It also failed as a guard: relative cd was never matched, and shell state does not persist across Bash invocations.

## Test plan

- `python3 -m json.tool ~/.claude/settings.json > /dev/null` passes.
- In a new Claude Code session, `cd <project-subdir>` with an absolute path is no longer denied.