### PR TITLE
fix(skills): align allowed-tools with !command usage

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -3,7 +3,7 @@ name: commit
 description: 未コミットの変更を分析し、論理的なグループに分類して適切な粒度でコミットするスキル。ユーザーが「コミットして」「変更をコミット」「commit」と言ったとき、または作業完了後にコミットを求められたときに使用する。
 disable-model-invocation: true
 effort: low
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git checkout:*), Bash(git branch:*), Bash(pre-commit:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git checkout:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*), Bash(pre-commit:*)
 ---
 
 # Git Commit

--- a/.claude/skills/refactor-code/SKILL.md
+++ b/.claude/skills/refactor-code/SKILL.md
@@ -3,7 +3,7 @@ name: refactor-code
 description: コード品質を改善するリファクタリングスキル。コメント整理、構造改善、未使用コード削除、テスト実行を6フェーズで実施する。ユーザーが「リファクタリングして」「コードを整理して」「コード品質を改善して」と言ったとき、またはコードレビュー後の改善作業に使用する。
 argument-hint: "[file or directory]"
 effort: high
-allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), MultiEdit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), MultiEdit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
 ---
 
 # Refactor Code

--- a/.claude/skills/update-arch/SKILL.md
+++ b/.claude/skills/update-arch/SKILL.md
@@ -2,7 +2,7 @@
 name: update-arch
 description: アーキテクチャドキュメント(docs/arch)の更新・初期化スキル。コード変更時に処理概要・処理フロー・データフローのドキュメント更新要否を判断し、必要に応じて更新する。docs/arch が存在しないプロジェクトでは初期化を行う。ユーザーがアーキテクチャドキュメントの作成・更新を求めたとき、または git commit 時の Hook から呼び出されたときに使用する。
 argument-hint: "[target directory]"
-allowed-tools: Read(*), Glob(*), Grep(*), Write(*), Edit(*), Bash(git:*), Bash(ls:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Write(*), Edit(*), Bash(git:*), Bash(ls:*), Bash(test:*)
 ---
 
 # Update Architecture Docs

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-readme
 description: プロジェクト構造とコードベースを分析して README.md を自動生成・更新するスキル。ユーザーが README の作成・更新を求めたとき、「README を書いて」「README を更新して」「ドキュメントを整備して」と言ったとき、またはプロジェクトの初期セットアップ後にドキュメント整備が必要なときに使用する。
-allowed-tools: Read(*), Glob(*), LS(*), Grep(*), Write(*)
+allowed-tools: Read(*), Glob(*), LS(*), Grep(*), Write(*), Bash(find:*), Bash(head:*), Bash(ls:*)
 ---
 
 # Update README


### PR DESCRIPTION
## Summary

- Skill frontmatter の `!command` (dynamic context injection) はスキル自身の `allowed-tools` のみを参照するようになったため、不足分を補う
- `commit`: `Bash(git diff:*)`, `Bash(git log:*)` を追加
- `update-arch`: `Bash(test:*)` を追加
- `update-readme`: `Bash(find:*)`, `Bash(head:*)`, `Bash(ls:*)` を追加
- `refactor-code`: `Bash(ls:*)` を追加

## Test plan

- 各スキル (`/commit`, `/update-arch`, `/update-readme`, `/refactor-code`) を実行し、Current state セクションが sandbox エラーなく解決することを確認