### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,10 @@
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
     "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
   },
-  "includeCoAuthoredBy": false,
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "allow": [
       "Bash(ls *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
     "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",


### PR DESCRIPTION
## Summary

Two doc-backed changes to keep `.claude/settings.json` aligned with the current Claude Code spec.

- **REQUIRED (deprecation):** `includeCoAuthoredBy` is listed as deprecated in the [official settings reference](https://code.claude.com/docs/en/settings) (see the "Key Deprecations & Recommendations" table) and the recommended replacement is the `attribution` setting. The existing value `false` suppressed only the `Co-authored-by:` trailer; the closest forward-compatible equivalent that preserves the repo's "no AI attribution" intent (verified against recent `git log`) is `attribution: { "commit": "", "pr": "" }`, which suppresses both commit and PR attribution strings. Note this is slightly broader than the legacy boolean: it also drops the "🤖 Generated with Claude Code" line if Claude Code would otherwise add one.
- **RECOMMENDED (best practice):** Add the documented `$schema` reference (`https://json.schemastore.org/claude-code-settings.json`) to `.claude/settings.json` so editors validate the file against the official spec. The "Key Notes" section of the [settings reference](https://code.claude.com/docs/en/settings) lists this as the recommended schema URL.

Skipped (ambiguous or no doc evidence today):
- Skill `allowed-tools` patterns mix `Bash(cmd:*)` and `Bash(cmd *)`. Both forms are documented as equivalent in the [permissions reference](https://code.claude.com/docs/en/permissions), so no change is required. PR #54 already normalised the alignment with `!command` injection.
- Env vars `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_CODE_DISABLE_AUTO_MEMORY`, and `CLAUDE_CODE_DISABLE_1M_CONTEXT` are all still documented in the [env-vars reference](https://code.claude.com/docs/en/env-vars) and [model-config](https://code.claude.com/docs/en/model-config). `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` is a no-op on Opus 4.7 but is not deprecated, so it stays.
- No new skill frontmatter field (e.g., `paths`, `when_to_use`, `hooks`, `shell`, `context`/`agent`) was found to be unambiguously required for existing skills; adopting them would be a feature change, not a doc-sync.

## Test plan

- [ ] Open `.claude/settings.json` in an editor that respects `$schema` (VS Code with JSON schema support) and confirm the keys validate without warnings.
- [ ] Launch `claude` in this repo, run `/doctor`, and verify no warning is emitted about a deprecated `includeCoAuthoredBy` setting.
- [ ] Run a commit through Claude Code (e.g. via `/commit`) and confirm the resulting commit message contains neither `Co-authored-by: Claude` nor `🤖 Generated with Claude Code`, matching the repo's existing commit style.
- [ ] Open a PR through `/pr-merge` (or `gh pr create` driven by Claude Code) and confirm the PR body has no auto-injected attribution footer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bm9wdjb3jKRdrne6riCPBa)_