### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -205,5 +205,5 @@
   "skipAutoPermissionPrompt": true,
   "remoteControlAtStartup": false,
   "editorMode": "vim",
-  "verbose": true
+  "viewMode": "verbose"
 }


### PR DESCRIPTION
## Summary

- REQUIRED: replace the undocumented top-level `verbose: true` boolean in `.claude/settings.json` with the documented `viewMode: "verbose"` setting. The settings reference lists `viewMode` (values: `"default" | "verbose" | "focus"`) as the canonical key for the default transcript view mode on startup; `verbose` is not in the settings table — only `--verbose` exists as a per-session CLI override. Ref: https://code.claude.com/docs/en/settings

## Test plan

- [ ] Launch `claude` from this repo and confirm the session starts in verbose transcript view (matches previous `verbose: true` behavior).
- [ ] Run `/doctor` and confirm no warnings about unknown settings keys.
- [ ] Confirm `--verbose` / `--no-verbose` CLI flags still override the setting for a single session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Th3ZT7hYyhWFn5pFrktL72)_