### PR TITLE
feat(skills): add python-refactor skill for measurement-driven refactoring

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,6 +39,7 @@
 | refactor-code        | コード品質改善のためのリファクタリング             |
 | typescript-dev-guide | TypeScript 開発ガイド                              |
 | python-dev-guide     | Python 開発ガイド                                  |
+| python-refactor      | Python の計測駆動リファクタリング（複雑性削減・コード健全性・共通化・マジックナンバー定数化） |
 | update-arch          | アーキテクチャドキュメント(docs/arch)の更新・初期化 |
 | update-readme        | プロジェクト構造分析による README.md 生成・更新     |
 | humanize             | AI 生成文章から AI らしさを取り除き自然な日本語に書き換える |

--- a/.claude/skills/python-refactor/SKILL.md
+++ b/.claude/skills/python-refactor/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: python-refactor
+description: Python コードの計測駆動リファクタリング支援。radon/lizard/vulture/pylint で計測し、複雑性削減・デッドコード除去・類似処理の共通化・マジックナンバー定数化を行う。「Python の複雑度を下げて」「Python の重複を統合」「Python のマジックナンバーを定数化」と言われたとき、または引数 complexity/code-health/dedupe/magic-numbers/full でモード指定された場合に使用する。
+argument-hint: "[full|complexity|code-health|dedupe|magic-numbers] [path]"
+effort: high
+allowed-tools:
+  - Read
+  - Edit
+  - MultiEdit
+  - Glob
+  - Grep
+  - Bash(uv:*)
+  - Bash(git:*)
+  - Bash(ls:*)
+  - Bash(find:*)
+  - Bash(grep:*)
+---
+
+# Python Refactor
+
+Python プロジェクト専用の計測駆動リファクタリング支援。計測ツール (radon / lizard / vulture / pylint) の出力をもとに、複雑性削減・デッドコード除去・類似処理の共通化・マジックナンバー定数化を進める。
+
+`$ARGUMENTS` の第 1 引数でモードを指定して個別実行できる。指定なしならフルモードで全フェーズを順に実施する。
+
+## refactor-code との棲み分け
+
+| スキル | 対象 | 駆動 |
+| --- | --- | --- |
+| `refactor-code` | 任意言語の汎用リファクタリング | 手作業ベース、6 フェーズ |
+| `python-refactor` | Python 限定 | 計測ツール駆動、モード分岐対応 |
+
+Python プロジェクトで計測値を見ながら進めたいなら本スキル、それ以外、または計測ツールを入れる前の整理は `refactor-code` を使う。
+
+## 機能インデックス
+
+個別実行したいモードを引数に渡す。`$ARGUMENTS` の第 1 トークンがモード、第 2 トークンが対象パス (省略時は `.`)。
+
+| モード | 引数 | 目的 | 主要ツール | 参照 |
+| --- | --- | --- | --- | --- |
+| フル | (空) または `full` | 全フェーズ順次実行 | radon / lizard / vulture / pylint | 本ファイル全体 |
+| 複雑性削減 | `complexity` | cyclomatic / cognitive 削減 | radon, lizard, wily | [references/complexity.md](references/complexity.md) |
+| コード健全性 | `code-health` | デッドコード除去・コメント整理 | vulture | [references/code-health.md](references/code-health.md) |
+| 類似処理共通化 | `dedupe` | パラメタライズ・設定駆動化・命名統一 | pylint, grep | [references/dedupe.md](references/dedupe.md) |
+| マジックナンバー定数化 | `magic-numbers` | 数値・文字列を定数 / Config 化 | grep, ruff | [references/magic-numbers.md](references/magic-numbers.md) |
+
+計測コマンドとツール一覧はすべて [references/tools.md](references/tools.md) に集約。
+
+## 引数によるモード分岐
+
+第 1 トークンを以下と完全一致で照合する (大文字小文字は区別、ハイフン必須)。
+
+- `complexity` / `code-health` / `dedupe` / `magic-numbers` / `full`
+
+一致しない場合はエラーとし、候補を提示してユーザー確認を取る。例:
+
+```
+入力: complex
+→ 不明なモード `complex` です。次のいずれかを指定してください: complexity / code-health / dedupe / magic-numbers / full
+```
+
+引数なしまたは `full` の場合、Phase 0 → 5 を順に実行する。それ以外は Phase 0 (準備) → Phase 1 の該当モード計測のみ → Phase 2 の該当改善 → Phase 4 (検証) → Phase 5 (ドキュメント整合) を実行する。
+
+## Phase 0: 準備
+
+1. `pyproject.toml` を Read し、`[dependency-groups]` の `dev` に必要ツール (モード別の最小セットは [tools.md](references/tools.md) 参照) が揃っているか確認
+2. 不足ツールがあればユーザーに一覧を提示し承認を得る:
+
+   ```
+   このモード (例: complexity) には radon, lizard, wily が必要ですが、現在 pyproject.toml に含まれていません。
+   `uv add --dev radon lizard wily` で追加してよいですか？
+   ```
+3. 承認後に `uv add --dev <tools>` を実行し、`uv sync` で同期
+4. `uv run pytest` を実行し、ベースラインのテストグリーンを確認。失敗があればリファクタリング前に修正する旨をユーザーに通知
+
+## Phase 1: 計測
+
+該当モードの計測コマンドを `uv run <tool>` 形式で実行し、結果を標準出力にそのまま提示する。ファイル保存はしない (`reports/` ディレクトリは作らない)。
+
+出力例の解釈 (各モードの読み方):
+
+- complexity: 関数単位で C 以上のランクが付いた箇所を改善対象として要約
+- code-health: 信頼度別に分類し、80% 以上を主対象、60-70% は偽陽性候補として注意喚起
+- dedupe: 6 行以上の重複ブロックを箇所ペアでリスト化
+- magic-numbers: ファイル × 行 × リテラル値で表化
+
+完全なコマンド一覧は [references/tools.md](references/tools.md) を参照。
+
+## Phase 2: 改善 (モード別)
+
+該当 references ファイルのパターンを適用する。SKILL.md には各モード 1 例だけ載せる。
+
+### complexity モード例 (Guard Clauses)
+
+```python
+# BEFORE
+def get_user_status(user):
+    if user:
+        if user.is_active:
+            if user.is_verified:
+                return "ok"
+    return "denied"
+
+# AFTER
+def get_user_status(user):
+    if user is None or not user.is_active or not user.is_verified:
+        return "denied"
+    return "ok"
+```
+
+→ 詳細パターン: [references/complexity.md](references/complexity.md)
+
+### code-health モード例 (Remove Commented Code)
+
+```python
+# BEFORE
+def total(items):
+    # total = 0
+    # for i in items: total += i.price
+    # return total
+    return sum(i.price for i in items)
+
+# AFTER
+def total(items):
+    return sum(i.price for i in items)
+```
+
+→ 詳細パターン: [references/code-health.md](references/code-health.md)
+
+### dedupe モード例 (Configuration Over Duplication)
+
+```python
+# BEFORE
+def process_csv(p): return parse(p, delimiter=",")
+def process_tsv(p): return parse(p, delimiter="\t")
+
+# AFTER
+FORMATS = {"csv": ",", "tsv": "\t"}
+def process_file(p, fmt): return parse(p, delimiter=FORMATS[fmt])
+```
+
+→ 詳細パターン: [references/dedupe.md](references/dedupe.md)
+
+### magic-numbers モード例 (Extract to Constants)
+
+```python
+# BEFORE
+if amount < 100:
+    fee = 2.50
+
+# AFTER
+from typing import Final
+SMALL_AMOUNT_THRESHOLD: Final = 100
+SMALL_FEE: Final = 2.50
+
+if amount < SMALL_AMOUNT_THRESHOLD:
+    fee = SMALL_FEE
+```
+
+→ 詳細パターン: [references/magic-numbers.md](references/magic-numbers.md)
+
+各改善ステップの後で `uv run pytest` を流し、テストがグリーンであることを確認する。
+
+## Phase 3: 横断適用順 (フルモードのみ)
+
+複数モードをまとめて適用するときは以下の順で行う。理由は、後段の効果が前段の整理に依存するため。
+
+1. `code-health` — デッドコードを先に消してノイズを減らす
+2. `dedupe` — 残ったコードの重複を統合
+3. `magic-numbers` — 統合後の関数で散らばっていた定数を整理
+4. `complexity` — 上記で簡素になったコードに対し最終的な複雑度調整
+
+## Phase 4: 検証
+
+```bash
+uv run pytest                         # テストグリーン
+uv run ruff check .                   # Lint
+uv run ruff format --check .          # フォーマット
+uv run mypy .                         # 型チェック
+uv run radon cc . -n C                # 複雑度ゲート
+uv run vulture . --min-confidence 80  # デッドコード再確認
+uv run wily diff HEAD~1               # 改善度
+```
+
+完全な検証コマンドリストは [references/tools.md](references/tools.md) の「最終検証コマンド一式」を参照。
+
+## Phase 5: ドキュメント整合性チェック
+
+リファクタリングで生じた構造変更がドキュメントと乖離していないか確認し、必要なら更新へ誘導する。
+
+判定とアクション:
+
+| 対象 | 判定基準 | アクション |
+| --- | --- | --- |
+| `docs/arch/` | 存在し、かつ処理フロー・モジュール構造・公開 API が変更された | `update-arch` スキルの呼び出しを提案 |
+| `README.md` | Quick Start / コマンド例 / プロジェクト構造のいずれかが変更された | `update-readme` スキルの呼び出しを提案 |
+| いずれも | 影響なし | 「ドキュメント影響なし: <理由>」を 1 行表示してスキップ |
+
+判定は `git diff --stat` と変更ファイル一覧から自動で見積もり、最終判断はユーザーに確認する。
+
+## 閾値要約
+
+| 観点 | 閾値 |
+| --- | --- |
+| 循環的複雑度 | C 以上 (≥ 11) で改善対象 |
+| 認知的複雑度 | > 15 で改善対象 |
+| 保守性指数 | < 65 で改善対象 |
+| 1 ファイル行数 | > 500 行で分割検討 |
+| 重複コード | ≥ 6 行のブロックは統合検討 |
+| デッドコード信頼度 | ≥ 80% で削除候補 |
+
+根拠と詳細は [references/tools.md](references/tools.md) を参照。
+
+## スコープ外
+
+以下は本スキルでは扱わない。
+
+- セキュリティスキャン (bandit / ruff S ルール)
+- テストカバレッジ・ミューテーションテスト (pytest-cov / mutmut)
+- 構文モダナイズ (pyupgrade / ruff UP ルール)
+- 品質ツール初期設定 (ruff / mypy 設定) — `python-dev-guide` を参照
+- pre-commit セットアップ — `python-dev-guide` を参照
+
+必要に応じて参考リポ [l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) の py-security / py-test-quality / py-modernize / py-quality-setup / py-git-hooks を直接参照する。
+
+## Key Principles
+
+1. 計測 → 改善 → 検証 → ドキュメント整合の順を守る
+2. テストグリーンを維持。テスト未整備のコードは先にテストを書く
+3. 大きな構造変更の前にユーザー確認を取る
+4. 過抽象化を避ける (`dedupe` の 3 回ルール参照)
+5. 出力・対話は日本語、コード内コメントは英語
+
+## 出典
+
+[l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) (MIT, Copyright 2025 Lars Marowsky-Brée) の py-refactor / py-complexity / py-code-health を参考に、dotfiles の規約 (`python-dev-guide`、`markdown-style`) に合わせて再構成。

--- a/.claude/skills/python-refactor/references/code-health.md
+++ b/.claude/skills/python-refactor/references/code-health.md
@@ -1,0 +1,143 @@
+# コード健全性パターン
+
+デッドコードとコメントアウトされた残骸を整理し、ノイズを減らす。重複の検出・統合は [dedupe.md](dedupe.md) を参照。
+
+## 検出コマンド
+
+```bash
+uv run vulture . --min-confidence 80                       # 信頼度 80% 以上
+uv run vulture . --min-confidence 80 --sort-by-size        # 大きい順
+uv run vulture . --min-confidence 80 --exclude tests,.venv
+```
+
+詳細は [tools.md](tools.md) を参照。
+
+## vulture 出力の読み方
+
+```
+src/billing.py:45: unused function 'calculate_tax' (80% confidence)
+src/processors.py:123: unused class 'LegacyProcessor' (90% confidence)
+src/config.py:12: unused variable 'debug_mode' (60% confidence)
+```
+
+信頼度の対応指針:
+
+| 信頼度 | 判断 |
+| --- | --- |
+| 60-70% | 偽陽性の可能性が高い。動的呼び出し・メタクラス・型注釈用途を疑う |
+| 80-89% | おそらく未使用。実際の呼び出し元を Grep で確認してから削除 |
+| 90-100% | ほぼ確実に未使用。削除可 |
+
+## 偽陽性のハンドリング
+
+vulture が誤って未使用と判定するケース:
+
+### 1. 動的呼び出し
+
+```python
+# getattr 経由で呼ばれている
+def plugin_handler() -> None: ...
+
+# 呼び出し例 (vulture からは見えない)
+getattr(module, "plugin_handler")()
+```
+
+### 2. フレームワーク慣習
+
+```python
+# ORM フィールド、テストフィクスチャ、ルートハンドラ など
+class User(models.Model):
+    email = models.EmailField()        # Django ORM が参照
+
+@pytest.fixture
+def temp_dir(): ...                    # pytest が呼び出し
+
+@app.route("/health")
+def health(): ...                      # フレームワークが登録
+```
+
+### 3. 公開 API
+
+```python
+# ライブラリの外部公開関数。プロジェクト内では未使用に見える
+def public_api(): ...
+```
+
+### 対応
+
+- 公開 API は `__all__` に明記し、whitelist で除外
+- フレームワーク慣習はディレクトリ単位で `--exclude` を当てる
+- 動的呼び出しは設計を見直すか、最小限の whitelist にとどめる
+
+whitelist は通常のモジュールとして書き、vulture に引数として渡す:
+
+```python
+# whitelist.py
+public_api  # type: ignore  # External consumers
+```
+
+```bash
+uv run vulture . whitelist.py --min-confidence 80
+```
+
+## 「使われていない＝本来使われるべきだった」ケース
+
+定数、型定義、エラークラスなどは「使うべき場所で使われていない」可能性がある。削除する前に以下を確認する。
+
+- 同名・類似名の文字列リテラルや magic value が他所にないか
+- 同じ責務を持つ重複実装がないか
+- リファクタリング途中で参照側だけ忘れられていないか
+
+該当する場合は削除ではなく参照側の修正を選ぶ。
+
+## Remove Dead Code
+
+```python
+# BEFORE: 2 年前に置き換えられた関数が残っている
+def old_calculate_price(item: Item) -> float:
+    return item.cost * 1.1
+
+def deprecated_handler(data: dict) -> None:
+    pass
+
+def calculate_price(item: Item) -> float:
+    return item.cost * (1 + item.tax_rate)
+
+# AFTER
+def calculate_price(item: Item) -> float:
+    return item.cost * (1 + item.tax_rate)
+```
+
+git 履歴で過去実装は追えるので、コードから削除する。
+
+## Remove Commented Code
+
+コメントアウトされた旧コードはノイズになる。
+
+```python
+# BEFORE
+def calculate_total(items: list[Item]) -> float:
+    # total = 0
+    # for item in items:
+    #     total += item.price * item.quantity
+    # return total
+    return sum(item.total_price() for item in items)
+
+# AFTER
+def calculate_total(items: list[Item]) -> float:
+    return sum(item.total_price() for item in items)
+```
+
+「あとで戻すかも」は git で復元できるため不要。
+
+## Verification Checklist
+
+- [ ] `uv run vulture . --min-confidence 80` が空、または偽陽性のみ
+- [ ] コメントアウトされたコードブロックが残っていない
+- [ ] 削除前にテストが通り、削除後もテストが通る
+- [ ] カバレッジが下がっていない
+- [ ] 必要なら whitelist.py を作って意図的な除外を明記
+
+## 出典
+
+[l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) (MIT) の py-code-health からデッドコード部分のみ抽出して翻案。

--- a/.claude/skills/python-refactor/references/complexity.md
+++ b/.claude/skills/python-refactor/references/complexity.md
@@ -1,0 +1,145 @@
+# 複雑性削減パターン
+
+循環的・認知的複雑度を下げ、保守性指数を高めるためのリファクタリングパターン集。
+
+## 計測コマンド要約
+
+```bash
+uv run radon cc . -n C -s           # cyclomatic ≥ 11 を表示
+uv run radon mi . -n B              # 保守性指数 < 65
+uv run lizard -C 15 -L 50 .         # 認知的複雑度・関数行数
+uv run wily diff HEAD~1             # 直前コミットからの改善差分
+```
+
+詳細は [tools.md](tools.md) を参照。
+
+## 改善パターン
+
+### 1. Extract Function
+
+長大な関数を意味のある小関数に分割する。各関数を単一責任に保つ。
+
+```python
+# BEFORE: cyclomatic 12、20 行超
+def process_order(order: dict) -> bool:
+    if not order.get("items"):
+        return False
+    if order["total"] < 0:
+        return False
+    # ... 支払い処理 ...
+    # ... 在庫更新 ...
+    # ... 通知送信 ...
+    return True
+
+# AFTER: 各関数 cyclomatic ≤ 3
+def process_order(order: dict) -> bool:
+    return is_valid_order(order) and process_payment(order) and finalize_order(order)
+```
+
+### 2. Guard Clauses
+
+深いネストを早期 return で平坦化する。
+
+```python
+# BEFORE: ネスト 3 段
+def get_user_status(user: User | None) -> str:
+    if user:
+        if user.is_active:
+            if user.is_verified:
+                return "ok"
+    return "denied"
+
+# AFTER: ガード節
+def get_user_status(user: User | None) -> str:
+    if user is None or not user.is_active or not user.is_verified:
+        return "denied"
+    return "ok"
+```
+
+### 3. Lookup Tables
+
+`if/elif` の連鎖を辞書による参照に置き換える。
+
+```python
+# BEFORE: cyclomatic 7
+def get_discount(tier: str, total: float) -> float:
+    if tier == "gold" and total > 1000:
+        return 0.20
+    elif tier == "gold":
+        return 0.15
+    elif tier == "silver" and total > 1000:
+        return 0.10
+    elif tier == "silver":
+        return 0.05
+    return 0.0
+
+# AFTER: cyclomatic 2
+DISCOUNT_TABLE: dict[tuple[str, bool], float] = {
+    ("gold", True): 0.20,
+    ("gold", False): 0.15,
+    ("silver", True): 0.10,
+    ("silver", False): 0.05,
+}
+
+def get_discount(tier: str, total: float) -> float:
+    return DISCOUNT_TABLE.get((tier, total > 1000), 0.0)
+```
+
+### 4. Repetitive Field Operations
+
+同形の `if` を繰り返すコードは `getattr` / `setattr` のループで畳む。
+
+```python
+# BEFORE: 同じ if を 4 回繰り返す
+def apply_secrets(config: EmailConfig, secrets: dict) -> None:
+    if config.smtp_host:
+        config.smtp_host = substitute(config.smtp_host, secrets)
+    if config.smtp_user:
+        config.smtp_user = substitute(config.smtp_user, secrets)
+    if config.smtp_password:
+        config.smtp_password = substitute(config.smtp_password, secrets)
+    if config.smtp_from:
+        config.smtp_from = substitute(config.smtp_from, secrets)
+
+# AFTER: ループで畳む
+SECRET_FIELDS = ("smtp_host", "smtp_user", "smtp_password", "smtp_from")
+
+def apply_secrets(config: EmailConfig, secrets: dict) -> None:
+    for field in SECRET_FIELDS:
+        if value := getattr(config, field, None):
+            setattr(config, field, substitute(value, secrets))
+```
+
+ただし型チェックは弱くなるので、フィールドが静的に決まる場合のみ使う。
+
+### 5. Extract Complex Type Definitions
+
+繰り返し登場する複雑な型注釈は `TypeAlias` として 1 箇所で定義する。
+
+```python
+# BEFORE: 同じ型が 8 箇所に散らばる
+def load(cache_mode: Literal["use", "only", "refresh"] | None) -> Data: ...
+def save(data: Data, cache_mode: Literal["use", "only", "refresh"] | None) -> None: ...
+
+# AFTER: 名前を付けて再利用
+type CacheMode = Literal["use", "only", "refresh"]
+type CacheModeOption = CacheMode | None
+
+def load(cache_mode: CacheModeOption) -> Data: ...
+def save(data: Data, cache_mode: CacheModeOption) -> None: ...
+```
+
+配置先の目安: モジュール内利用なら同モジュール冒頭、プロジェクト横断なら `types.py`。
+
+## Verification Checklist
+
+- [ ] `uv run radon cc . -n C` で C 以上の関数が報告されない（または対処済み）
+- [ ] `uv run lizard -C 15 .` で認知的複雑度の警告が出ない
+- [ ] `uv run radon mi . -n B` で保守性指数 < 65 のモジュールがない
+- [ ] 1 ファイル > 500 行は分割するか分割不可な理由を確認
+- [ ] テストグリーンを維持
+- [ ] `uv run wily diff HEAD~1` で改善方向を確認
+
+## 出典
+
+[l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) (MIT) の py-complexity を Python 3.12+ に合わせて翻案。

--- a/.claude/skills/python-refactor/references/dedupe.md
+++ b/.claude/skills/python-refactor/references/dedupe.md
@@ -1,0 +1,258 @@
+# 類似処理の共通化・正規化パターン
+
+インクリメンタル開発で蓄積した「似ているが微妙に違う」コードを統合し、命名・シグネチャを揃えるためのパターン集。
+
+## 類似コードの検出
+
+```bash
+# 重複コード検出 (デフォルト 4 行以上)
+uv run pylint --disable=all --enable=duplicate-code --recursive=y .
+
+# しきい値を 6 行に上げてノイズを減らす
+uv run pylint --disable=all --enable=duplicate-code \
+    --duplicate-code-min-lines=6 --recursive=y .
+```
+
+語幹で類似関数を探す:
+
+```bash
+grep -rnE 'def (process|handle|fetch|create|update|delete)_[a-z_]+' \
+    --include='*.py' .
+```
+
+詳細は [tools.md](tools.md) を参照。
+
+## 改善パターン
+
+### 1. Parameterize Function
+
+ほぼ同じ処理を型パラメータで 1 つに統合する。
+
+```python
+# BEFORE: 戻り値の型だけ違う関数が並ぶ
+def process_user(data: dict) -> User:
+    if not data.get("email"):
+        raise ValueError("email required")
+    if not data.get("name"):
+        raise ValueError("name required")
+    return User(email=data["email"], name=data["name"])
+
+def process_admin(data: dict) -> Admin:
+    if not data.get("email"):
+        raise ValueError("email required")
+    if not data.get("name"):
+        raise ValueError("name required")
+    return Admin(email=data["email"], name=data["name"])
+
+# AFTER: TypeVar で統合 (PEP 695 構文)
+def process_entity[T: (User, Admin)](data: dict, cls: type[T]) -> T:
+    if not data.get("email"):
+        raise ValueError("email required")
+    if not data.get("name"):
+        raise ValueError("name required")
+    return cls(email=data["email"], name=data["name"])
+
+user = process_entity(payload, User)
+admin = process_entity(payload, Admin)
+```
+
+### 2. Extract Common Logic
+
+複数関数で重複するバリデーションを切り出す。
+
+```python
+# BEFORE: バリデーションが create / update に重複
+def create_user(email: str, age: int) -> User:
+    if "@" not in email:
+        raise ValueError("invalid email")
+    if not 0 <= age <= 150:
+        raise ValueError("invalid age")
+    return User(email=email, age=age)
+
+def update_user(user_id: int, email: str, age: int) -> User:
+    if "@" not in email:
+        raise ValueError("invalid email")
+    if not 0 <= age <= 150:
+        raise ValueError("invalid age")
+    user = get_user(user_id)
+    user.email = email
+    user.age = age
+    return user
+
+# AFTER: バリデーションを抽出
+def _validate_user_input(email: str, age: int) -> None:
+    if "@" not in email:
+        raise ValueError("invalid email")
+    if not 0 <= age <= 150:
+        raise ValueError("invalid age")
+
+def create_user(email: str, age: int) -> User:
+    _validate_user_input(email, age)
+    return User(email=email, age=age)
+
+def update_user(user_id: int, email: str, age: int) -> User:
+    _validate_user_input(email, age)
+    user = get_user(user_id)
+    user.email = email
+    user.age = age
+    return user
+```
+
+### 3. Configuration Over Duplication
+
+「ほぼ同じだが定数だけ違う」関数群は設定を引数化して 1 つに集約する。
+
+```python
+# BEFORE: パーサが 3 つ並ぶ
+def process_csv(path: str) -> list[dict]:
+    return parse_file(path, delimiter=",", encoding="utf-8", skip_header=True)
+
+def process_tsv(path: str) -> list[dict]:
+    return parse_file(path, delimiter="\t", encoding="utf-8", skip_header=True)
+
+def process_psv(path: str) -> list[dict]:
+    return parse_file(path, delimiter="|", encoding="utf-8", skip_header=True)
+
+# AFTER: 設定駆動
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class FileFormat:
+    delimiter: str
+    encoding: str = "utf-8"
+    skip_header: bool = True
+
+FORMATS: dict[str, FileFormat] = {
+    "csv": FileFormat(","),
+    "tsv": FileFormat("\t"),
+    "psv": FileFormat("|"),
+}
+
+def process_file(path: str, fmt: str) -> list[dict]:
+    spec = FORMATS[fmt]
+    return parse_file(path, delimiter=spec.delimiter,
+                      encoding=spec.encoding, skip_header=spec.skip_header)
+```
+
+### 4. シグネチャ・命名統一
+
+似た関数の引数順・名前・戻り値型を揃えると、呼び出し側のテンプレートが安定する。
+
+- 動詞は同じ意味で同じ語を使う (例: 取得は `get_` か `fetch_` のどちらかに統一)
+- 主キーの引数名は全関数で同じに (例: 常に `user_id: int`)
+- 戻り値は同じ抽象度で揃える (例: `User | None` か例外送出かを統一)
+
+```python
+# BEFORE: 不揃い
+def get_user(id: int) -> dict: ...
+def fetch_user_by_id(user_id: int) -> User | None: ...
+def find_user(uid: int) -> User: ...
+
+# AFTER: get_<entity>(<entity>_id) -> <Entity> | None で統一
+def get_user(user_id: int) -> User | None: ...
+def get_order(order_id: int) -> Order | None: ...
+```
+
+### 5. 文字列分岐の Enum / Literal 化
+
+文字列キーで分岐するコードは `StrEnum` または `Literal` に置き換えると、typo を型チェックで検出できる。
+
+```python
+# BEFORE: 文字列直書き
+def select_strategy(mode: str) -> Strategy:
+    if mode == "fast":
+        return FastStrategy()
+    if mode == "safe":
+        return SafeStrategy()
+    if mode == "balanced":
+        return BalancedStrategy()
+    raise ValueError(f"unknown mode: {mode}")
+
+# AFTER: StrEnum + dispatch
+from enum import StrEnum
+
+class Mode(StrEnum):
+    FAST = "fast"
+    SAFE = "safe"
+    BALANCED = "balanced"
+
+STRATEGIES: dict[Mode, type[Strategy]] = {
+    Mode.FAST: FastStrategy,
+    Mode.SAFE: SafeStrategy,
+    Mode.BALANCED: BalancedStrategy,
+}
+
+def select_strategy(mode: Mode) -> Strategy:
+    return STRATEGIES[mode]()
+```
+
+少数の固定値で外部 API シグネチャを変えたくない場合は `Literal["fast", "safe", "balanced"]` を使う。
+
+### 6. Template Method
+
+「処理の骨格は同じ、一部の手順だけ違う」関数群は基底クラスにテンプレートを置く。
+
+```python
+# BEFORE: import → 加工 → 保存 の骨格が同じレポート生成関数が複数
+def generate_sales_report(period: str) -> Report:
+    raw = load_sales(period)
+    cleaned = clean_rows(raw)
+    metrics = compute_sales_metrics(cleaned)
+    return save_report(metrics, kind="sales")
+
+def generate_traffic_report(period: str) -> Report:
+    raw = load_traffic(period)
+    cleaned = clean_rows(raw)
+    metrics = compute_traffic_metrics(cleaned)
+    return save_report(metrics, kind="traffic")
+
+# AFTER: 骨格を基底クラスに、差分だけサブクラスに
+from abc import ABC, abstractmethod
+
+class ReportBuilder(ABC):
+    kind: str
+
+    def build(self, period: str) -> Report:
+        raw = self.load(period)
+        cleaned = clean_rows(raw)
+        metrics = self.compute_metrics(cleaned)
+        return save_report(metrics, kind=self.kind)
+
+    @abstractmethod
+    def load(self, period: str) -> list[dict]: ...
+
+    @abstractmethod
+    def compute_metrics(self, rows: list[dict]) -> dict: ...
+
+class SalesReport(ReportBuilder):
+    kind = "sales"
+    def load(self, period): return load_sales(period)
+    def compute_metrics(self, rows): return compute_sales_metrics(rows)
+
+class TrafficReport(ReportBuilder):
+    kind = "traffic"
+    def load(self, period): return load_traffic(period)
+    def compute_metrics(self, rows): return compute_traffic_metrics(rows)
+```
+
+差分が 1, 2 個ならクラス化せず高階関数 (`build(load_fn, metrics_fn, kind)`) でも良い。
+
+## 過抽象化への警戒
+
+統合は便利だが行きすぎると逆に読みにくくなる。判断の目安:
+
+- 3 回ルール: 同じパターンが 3 回出てから抽出する。2 回までは複製のままにしておく
+- 統合後にパラメータが 5 個以上になる、もしくは `if kind == "..."` 分岐が新たに増えるなら、分離したままが正解
+- ドメイン的に別概念なら統合しない (例: `User` と `Product` のバリデーションが似ていても無理に共通化しない)
+
+## Verification Checklist
+
+- [ ] `uv run pylint --disable=all --enable=duplicate-code --recursive=y .` で 6 行以上の重複が報告されない
+- [ ] 命名・シグネチャが揃っている
+- [ ] 文字列分岐が Enum / Literal で型付けされている
+- [ ] テストグリーンを維持
+- [ ] 統合の結果、可読性が上がったか目視で確認
+
+## 出典
+
+[l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) (MIT) の py-code-health 重複統合部分を起点に、Enum 化・テンプレートメソッド・命名統一を加筆して翻案。

--- a/.claude/skills/python-refactor/references/magic-numbers.md
+++ b/.claude/skills/python-refactor/references/magic-numbers.md
@@ -1,0 +1,177 @@
+# マジックナンバー定数化パターン
+
+コード中に散らばった数値・文字列リテラルを意味のある名前に変え、変更可能性と読みやすさを高める。
+
+## 検出コマンド
+
+```bash
+# 2 桁以上の数値リテラル
+grep -rnE '\b[0-9]{2,}\b' --include='*.py' .
+
+# 短い文字列リテラル (キーやモード名の候補)
+grep -rnE '"[a-zA-Z_]{2,20}"' --include='*.py' . \
+    | grep -v 'docstring\|"""'
+
+# ruff の magic value ルール
+uv run ruff check . --select PLR2004
+```
+
+詳細は [tools.md](tools.md) を参照。
+
+## 改善パターン
+
+### 1. Extract to Constants
+
+繰り返し登場するリテラルをモジュールトップの `Final` 定数にする。
+
+```python
+# BEFORE
+def calculate_fee(amount: int) -> float:
+    if amount < 100:
+        return 2.50
+    if amount < 1000:
+        return 5.00
+    return 10.00
+
+# AFTER
+from typing import Final
+
+SMALL_AMOUNT_THRESHOLD: Final = 100
+MEDIUM_AMOUNT_THRESHOLD: Final = 1000
+SMALL_FEE: Final = 2.50
+MEDIUM_FEE: Final = 5.00
+LARGE_FEE: Final = 10.00
+
+def calculate_fee(amount: int) -> float:
+    if amount < SMALL_AMOUNT_THRESHOLD:
+        return SMALL_FEE
+    if amount < MEDIUM_AMOUNT_THRESHOLD:
+        return MEDIUM_FEE
+    return LARGE_FEE
+```
+
+### 2. Config クラス化
+
+関連する定数群は `dataclass` にまとめると、グルーピングと型の表現力が上がる。
+
+```python
+# BEFORE: 関連する定数が散らばる
+SMALL_AMOUNT_THRESHOLD: Final = 100
+MEDIUM_AMOUNT_THRESHOLD: Final = 1000
+SMALL_FEE: Final = 2.50
+MEDIUM_FEE: Final = 5.00
+LARGE_FEE: Final = 10.00
+PREMIUM_DISCOUNT: Final = 0.5
+
+# AFTER: グループ化
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass(frozen=True)
+class FeeConfig:
+    small_threshold: int = 100
+    medium_threshold: int = 1000
+    small_fee: float = 2.50
+    medium_fee: float = 5.00
+    large_fee: float = 10.00
+    premium_discount: float = 0.5
+
+FEE_CONFIG: Final = FeeConfig()
+
+def calculate_fee(amount: int) -> float:
+    if amount < FEE_CONFIG.small_threshold:
+        return FEE_CONFIG.small_fee
+    if amount < FEE_CONFIG.medium_threshold:
+        return FEE_CONFIG.medium_fee
+    return FEE_CONFIG.large_fee
+```
+
+### 3. 単位を名前に含める
+
+数値の単位は名前で表現する。`30` と `30.0` が秒なのかミリ秒なのかメガバイトなのかを呼び出し側で迷わせない。
+
+```python
+# BEFORE
+SESSION_TIMEOUT = 30                # 秒？ミリ秒？
+BUFFER_SIZE = 1024                  # バイト？KB？
+
+# AFTER
+SESSION_TIMEOUT_SECONDS: Final = 30
+BUFFER_SIZE_BYTES: Final = 1024
+MAX_RETRY_DELAY_MS: Final = 5000
+```
+
+`timedelta` を使えるところは使う方が安全:
+
+```python
+from datetime import timedelta
+
+SESSION_TIMEOUT: Final = timedelta(seconds=30)
+```
+
+### 4. pydantic-settings での環境変数オーバーライド
+
+実行環境ごとに変えたい値は `pydantic-settings` の `BaseSettings` に集約し、環境変数で上書きできるようにする。
+
+```python
+# AFTER
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class AppSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="APP_", env_file=".env")
+
+    session_timeout_seconds: int = Field(default=30, ge=1)
+    buffer_size_bytes: int = Field(default=1024, ge=64)
+    max_retry_delay_ms: int = Field(default=5000, ge=0)
+
+settings = AppSettings()
+```
+
+`APP_SESSION_TIMEOUT_SECONDS=60` を環境変数で渡すだけで上書きされる。バリデーションが付いてくる利点もある。
+
+### 5. テストでの定数置換
+
+テストでは `monkeypatch.setattr` で定数を一時的に置き換える。`importlib.reload` を避けられる。
+
+```python
+# tests/test_fees.py
+def test_small_fee_threshold(monkeypatch):
+    from myapp import fees
+    monkeypatch.setattr(fees.FEE_CONFIG, "small_threshold", 200)
+    assert fees.calculate_fee(150) == fees.FEE_CONFIG.small_fee
+```
+
+`pydantic-settings` の場合はテスト用 fixture でインスタンスを差し替える:
+
+```python
+@pytest.fixture
+def test_settings(monkeypatch):
+    monkeypatch.setenv("APP_SESSION_TIMEOUT_SECONDS", "5")
+    return AppSettings()
+```
+
+## 除外対象
+
+すべての数値・文字列を定数化する必要はない。以下はそのままで読みやすい。
+
+- `0`, `1`, `-1` (初期値・インクリメント・末尾アクセス)
+- `2` (二乗、ペア)
+- 自己説明的なリテラル (`if len(items) == 1:`、`return [0] * n`)
+- テストの期待値 (`assert calculate(3, 4) == 12`)
+- 文字列キーで「その場限り、1 箇所のみ」のもの
+
+判断基準: 同じ値が 2 箇所以上に現れる、または値の意味が呼び出し側から読み取れない場合に定数化する。
+
+## Verification Checklist
+
+- [ ] `uv run ruff check . --select PLR2004` が空、または意図的な例外のみ
+- [ ] 同じリテラルが複数箇所で重複していない
+- [ ] 数値定数の単位が名前で明示されている
+- [ ] 環境ごとに変える値は `pydantic-settings` でオーバーライド可能
+- [ ] テストで定数置換が必要な箇所は fixture / monkeypatch で対応
+- [ ] テストグリーンを維持
+
+## 出典
+
+[l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) (MIT) の py-complexity「Extract Magic Numbers」を切り出して拡張し、`pydantic-settings` と単位命名を加えて翻案。

--- a/.claude/skills/python-refactor/references/tools.md
+++ b/.claude/skills/python-refactor/references/tools.md
@@ -1,0 +1,122 @@
+# 計測ツールリファレンス
+
+`python-refactor` で使用する計測ツールの一覧、閾値、インストール方法、コマンド集。
+
+## ツール一覧
+
+| ツール | 用途 | 閾値 | 主要オプション |
+| --- | --- | --- | --- |
+| radon | 循環的複雑度 / 保守性指数 | cyclomatic ≥ 11 (C ランク以上)、MI < 65 | `cc -n C -s`、`mi -n B` |
+| lizard | 認知的複雑度 / 行数 | cognitive > 15、関数行数 > 50 | `-C 15 -L 50` |
+| wily | 複雑性トレンドの履歴追跡 | — | `build .` で初期化、`diff HEAD~1` で差分 |
+| xenon | 閾値ゲート (CI 用) | `--max-absolute C --max-modules B` | パイプライン用 |
+| vulture | デッドコード検出 (AST 解析) | confidence ≥ 80 推奨 | `--min-confidence 80` |
+| pylint | 重複コード検出 | duplicate-code-min-lines = 6 | `--disable=all --enable=duplicate-code` |
+| ruff | Lint / Format | UP / S / B / SIM ルール | `check`、`format` |
+| mypy | 型チェック | strict | `--strict` |
+| pytest | テスト実行 | カバレッジ ≥ 80% (任意) | `--cov` |
+
+## モード別の最小ツールセット
+
+| モード | 必須ツール |
+| --- | --- |
+| complexity | radon, lizard, wily |
+| code-health | vulture |
+| dedupe | pylint |
+| magic-numbers | (grep のみで可、ruff は任意) |
+| full | radon, lizard, wily, vulture, pylint |
+
+## 依存関係の追加
+
+`pyproject.toml` の `[dependency-groups]` セクションに dev グループとして追加する。`python-dev-guide` のテンプレートに以下を加える。
+
+```toml
+[dependency-groups]
+dev = [
+    "radon",
+    "lizard",
+    "wily",
+    "vulture",
+    "pylint",
+    "ruff",
+    "mypy",
+    "pytest",
+]
+```
+
+インストール:
+
+```bash
+uv add --dev radon lizard wily vulture pylint
+uv sync
+```
+
+不足ツールは Phase 0 で対象モードに必要な分のみを提示し、ユーザー承認を得てから追加する。
+
+## 計測コマンド集
+
+すべて `uv run` 経由で実行し、結果は標準出力にそのまま流す（ファイル保存はしない）。
+
+### Complexity モード
+
+```bash
+uv run radon cc . -n C -s                 # cyclomatic C ランク以上
+uv run radon mi . -n B                    # 保守性指数 B 未満
+uv run lizard -C 15 -L 50 .               # 認知的複雑度 / 関数行数
+uv run wily build .                       # 初回のみ
+uv run wily diff HEAD~1                   # 直前コミットからの差分
+```
+
+### Code Health モード
+
+```bash
+uv run vulture . --min-confidence 80                      # 信頼度 80% 以上
+uv run vulture . --min-confidence 80 --sort-by-size       # 大きい順
+uv run vulture . --min-confidence 80 --exclude tests,.venv
+```
+
+### Dedupe モード
+
+```bash
+uv run pylint --disable=all --enable=duplicate-code --recursive=y .
+uv run pylint --disable=all --enable=duplicate-code \
+    --duplicate-code-min-lines=6 --recursive=y .
+```
+
+補助的に grep で類似関数名を探す:
+
+```bash
+grep -rnE 'def (process|handle|fetch|create)_[a-z_]+' --include='*.py' .
+```
+
+### Magic Numbers モード
+
+```bash
+# 2 桁以上の数値リテラル
+grep -rnE '\b[0-9]{2,}\b' --include='*.py' .
+
+# 短い文字列リテラル (キーやモード名の候補)
+grep -rnE '"[a-zA-Z_]{2,20}"' --include='*.py' . \
+    | grep -v 'docstring\|"""\|""'
+
+# ruff の M (magic value) ルール
+uv run ruff check . --select PLR2004
+```
+
+## 最終検証コマンド一式
+
+Phase 4 で実行する。
+
+```bash
+uv run pytest                              # テストグリーン維持
+uv run ruff check .                        # Lint
+uv run ruff format --check .               # フォーマット
+uv run mypy .                              # 型チェック
+uv run radon cc . -n C                     # 複雑度ゲート
+uv run vulture . --min-confidence 80       # デッドコード再確認
+uv run wily diff HEAD~1                    # 改善度の可視化
+```
+
+## 出典
+
+ツール選定と閾値は [l-mb/python-refactoring-skills](https://github.com/l-mb/python-refactoring-skills) (MIT, Copyright 2025 Lars Marowsky-Brée) を参考に、dotfiles の `python-dev-guide` 規約に合わせて調整。


### PR DESCRIPTION
Adapt l-mb/python-refactoring-skills (MIT) into a single dotfiles skill
with mode-based dispatch: full / complexity / code-health / dedupe /
magic-numbers. Detailed patterns split into references/ subdirectory
following the python-dev-guide structure.