### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -202,8 +202,6 @@
   "alwaysThinkingEnabled": true,
   "plansDirectory": ".claude/plans",
   "autoMemoryEnabled": false,
-  "skipAutoPermissionPrompt": true,
-  "remoteControlAtStartup": false,
   "editorMode": "vim",
   "viewMode": "verbose"
 }


### PR DESCRIPTION
## Summary

- **REQUIRED**: Drop `skipAutoPermissionPrompt: true` from `.claude/settings.json`. The key is not present in the current Claude Code settings reference (verified by searching the page text). Auto mode's opt-in prompt is dismissed via the in-session "No, don't ask again" option, not a settings key. Doc: <https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode>, <https://code.claude.com/docs/en/settings>
- **REQUIRED**: Drop `remoteControlAtStartup: false` from `.claude/settings.json`. The key is not present in the current settings reference. The default behavior already matches the intended `false` value: Remote Control activates only on explicit `claude remote-control`, `--remote-control`, or `/remote-control`. The documented related key is `disableRemoteControl` (v2.1.128+), which blocks Remote Control entirely — a different intent, so it is not introduced here. Doc: <https://code.claude.com/docs/en/remote-control#start-a-remote-control-session>, <https://code.claude.com/docs/en/settings>

The rest of the repo's Claude Code configuration was checked against the latest docs (skills, sub-agents, hooks, memory, env vars, attribution) and is already consistent. Optional new conveniences (`skillOverrides`, `skillListingBudgetFraction`, `maxSkillDescriptionChars`, `claudeMdExcludes`, `${CLAUDE_SKILL_DIR}`) are not adopted here since the repo has no concrete need.

## Test plan

- [ ] `jq . .claude/settings.json` parses successfully and no longer contains `skipAutoPermissionPrompt` or `remoteControlAtStartup`.
- [ ] Start Claude Code at `~/.claude/` (this dotfiles symlink target) and confirm it boots without warnings about unknown settings keys.
- [ ] Confirm Remote Control still requires explicit invocation (`claude remote-control` / `--remote-control` / `/remote-control`) and does not auto-start.
- [ ] Confirm `defaultMode: "auto"` continues to take effect at user-settings scope as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmLxzVB9uezkAGNvvpvaxm)_