### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -195,7 +195,7 @@
       }
     }
   },
-  "language": "Japanese",
+  "language": "japanese",
   "sandbox": {
     "enabled": false
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -153,7 +153,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/skills/python-refactor/SKILL.md
+++ b/.claude/skills/python-refactor/SKILL.md
@@ -6,7 +6,6 @@ effort: high
 allowed-tools:
   - Read
   - Edit
-  - MultiEdit
   - Glob
   - Grep
   - Bash(uv:*)

--- a/.claude/skills/refactor-code/SKILL.md
+++ b/.claude/skills/refactor-code/SKILL.md
@@ -3,7 +3,7 @@ name: refactor-code
 description: コード品質を改善するリファクタリングスキル。コメント整理、構造改善、未使用コード削除、テスト実行を6フェーズで実施する。ユーザーが「リファクタリングして」「コードを整理して」「コード品質を改善して」と言ったとき、またはコードレビュー後の改善作業に使用する。
 argument-hint: "[file or directory]"
 effort: high
-allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), MultiEdit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
 ---
 
 # Refactor Code


### PR DESCRIPTION
## Summary

- **REQUIRED**: Removed `MultiEdit` from the `PostToolUse` hook matcher and from the `refactor-code` and `python-refactor` skills' `allowed-tools`. The `MultiEdit` tool was retired from Claude Code; only `Edit` and `Write` remain for file modification (see the canonical tool-name list in [hooks docs](https://code.claude.com/docs/en/hooks)). Existing entries are silently no-ops, but keeping them invites stale config drift.
- **RECOMMENDED**: Lowercased `settings.json` `language` value from `"Japanese"` to `"japanese"` so it matches the [official settings reference example](https://code.claude.com/docs/en/settings) (`e.g., "japanese", "spanish", "french"`).

## Test plan

- [ ] `jq . .claude/settings.json` parses cleanly and shows `"matcher": "Edit|Write"` and `"language": "japanese"`.
- [ ] `grep -r "MultiEdit" .claude/` returns no matches.
- [ ] Start a new Claude Code session and confirm the markdown-lint / open-plan-vscode `PostToolUse` hooks still fire when files are edited.
- [ ] Verify Claude continues to reply in Japanese (cross-checked against the `常に日本語で会話する` instruction in `.claude/CLAUDE.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_017JS2mQJfHJxH3GAMwfL4PQ)_