### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,10 +119,11 @@
         ]
       },
       {
-        "matcher": "Bash(git commit*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit *)",
             "command": "$HOME/.claude/hooks/check-arch-docs.sh",
             "timeout": 10
           }


### PR DESCRIPTION
## Summary

- REQUIRED — Fix malformed `PreToolUse` hook matcher in `.claude/settings.json`. The matcher `"Bash(git commit*)"` contains special characters and is therefore evaluated as a JavaScript regex per [hooks docs](https://code.claude.com/docs/en/hooks), which never matches the tool name `Bash`. Replace with documented format: `matcher: "Bash"` plus the `if` field for inner Bash command filtering using permission-rule syntax. Without this fix, `check-arch-docs.sh` silently never fires on `git commit`.

Other areas were reviewed against the [settings](https://code.claude.com/docs/en/settings), [skills](https://code.claude.com/docs/en/skills), [memory](https://code.claude.com/docs/en/memory), [permissions](https://code.claude.com/docs/en/permissions), [env vars](https://code.claude.com/docs/en/env-vars), and [model-config](https://code.claude.com/docs/en/model-config) docs. All other settings keys, hook events, env vars, skill frontmatter fields, and rule file frontmatter are still current and non-deprecated. No further changes required.

## Test plan

- [ ] Run `claude` in this repo and stage a code file under a project that has `docs/arch/`.
- [ ] Attempt `git commit` via the Bash tool. The hook should now fire and emit the `BLOCK: docs/arch ...` message from `check-arch-docs.sh`.
- [ ] Verify other hooks still fire as before: `validate-rm.sh` on any `Bash` call, `lint-markdown.sh` and `open-plan-vscode.sh` on `Edit|Write|MultiEdit`.
- [ ] Confirm `settings.json` still validates against `https://json.schemastore.org/claude-code-settings.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Z4zyNgLMbqBhXwtTEV9Q3)_