### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -153,7 +153,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/skills/python-refactor/SKILL.md
+++ b/.claude/skills/python-refactor/SKILL.md
@@ -6,7 +6,6 @@ effort: high
 allowed-tools:
   - Read
   - Edit
-  - MultiEdit
   - Glob
   - Grep
   - Bash(uv:*)

--- a/.claude/skills/refactor-code/SKILL.md
+++ b/.claude/skills/refactor-code/SKILL.md
@@ -3,7 +3,7 @@ name: refactor-code
 description: コード品質を改善するリファクタリングスキル。コメント整理、構造改善、未使用コード削除、テスト実行を6フェーズで実施する。ユーザーが「リファクタリングして」「コードを整理して」「コード品質を改善して」と言ったとき、またはコードレビュー後の改善作業に使用する。
 argument-hint: "[file or directory]"
 effort: high
-allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), MultiEdit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
 ---
 
 # Refactor Code

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-readme
 description: プロジェクト構造とコードベースを分析して README.md を自動生成・更新するスキル。ユーザーが README の作成・更新を求めたとき、「README を書いて」「README を更新して」「ドキュメントを整備して」と言ったとき、またはプロジェクトの初期セットアップ後にドキュメント整備が必要なときに使用する。
-allowed-tools: Read(*), Glob(*), LS(*), Grep(*), Write(*), Bash(find:*), Bash(head:*), Bash(ls:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Write(*), Bash(find:*), Bash(head:*), Bash(ls:*)
 ---
 
 # Update README


### PR DESCRIPTION
## Summary

- **REQUIRED (removed tool):** `MultiEdit` no longer appears in the official Claude Code [tools reference](https://code.claude.com/docs/en/tools-reference) — the built-in editing tools are now `Edit`, `Write`, and `NotebookEdit`. Dropped the dead `MultiEdit` entry from `.claude/settings.json`'s `PostToolUse` matcher (`Edit|Write|MultiEdit` → `Edit|Write`) and from `python-refactor` / `refactor-code` skill `allowed-tools`. The [hooks reference](https://code.claude.com/docs/en/hooks) also lists current valid tool-name matchers and does not include `MultiEdit`.
- **REQUIRED (invalid tool name):** `LS` is not a Claude Code tool — directory listing is performed via Bash `ls`, as documented in the [tools reference](https://code.claude.com/docs/en/tools-reference) (no `LS` row). Removed the dead `LS(*)` entry from `update-readme` skill `allowed-tools`.

## Test plan

- [ ] `cat .claude/settings.json | jq '.hooks.PostToolUse[0].matcher'` returns `"Edit|Write"` (no `MultiEdit`).
- [ ] `grep -R "MultiEdit" .claude` returns no matches.
- [ ] `grep -R "LS(" .claude/skills` returns no matches.
- [ ] Start a fresh Claude Code session in this repo and run `/python-refactor`, `/refactor-code`, `/update-readme` — each skill loads without warnings about unknown tools.
- [ ] After editing any file, confirm the `PostToolUse` hook (`lint-markdown.sh`, `open-plan-vscode.sh`) still fires on `Edit` / `Write`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JnhybHeLcvwnJ4PJfMKunZ)_