### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,10 +119,11 @@
         ]
       },
       {
-        "matcher": "Bash(git commit*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit *)",
             "command": "$HOME/.claude/hooks/check-arch-docs.sh",
             "timeout": 10
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -154,7 +154,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/skills/python-refactor/SKILL.md
+++ b/.claude/skills/python-refactor/SKILL.md
@@ -6,7 +6,6 @@ effort: high
 allowed-tools:
   - Read
   - Edit
-  - MultiEdit
   - Glob
   - Grep
   - Bash(uv:*)

--- a/.claude/skills/refactor-code/SKILL.md
+++ b/.claude/skills/refactor-code/SKILL.md
@@ -3,7 +3,7 @@ name: refactor-code
 description: コード品質を改善するリファクタリングスキル。コメント整理、構造改善、未使用コード削除、テスト実行を6フェーズで実施する。ユーザーが「リファクタリングして」「コードを整理して」「コード品質を改善して」と言ったとき、またはコードレビュー後の改善作業に使用する。
 argument-hint: "[file or directory]"
 effort: high
-allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), MultiEdit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Edit(*), Bash(find:*), Bash(grep:*), Bash(git:*), Bash(ls:*), Bash(pytest:*), Bash(npm:*), Bash(cargo:*)
 ---
 
 # Refactor Code

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-readme
 description: プロジェクト構造とコードベースを分析して README.md を自動生成・更新するスキル。ユーザーが README の作成・更新を求めたとき、「README を書いて」「README を更新して」「ドキュメントを整備して」と言ったとき、またはプロジェクトの初期セットアップ後にドキュメント整備が必要なときに使用する。
-allowed-tools: Read(*), Glob(*), LS(*), Grep(*), Write(*), Bash(find:*), Bash(head:*), Bash(ls:*)
+allowed-tools: Read(*), Glob(*), Grep(*), Write(*), Bash(find:*), Bash(head:*), Bash(ls:*)
 ---
 
 # Update README


### PR DESCRIPTION
## Summary

- **REQUIRED — Hook matcher syntax (`Bash(git commit*)` never fires).** Per the [hooks reference](https://code.claude.com/docs/en/hooks), matchers containing characters other than letters / digits / `_` / `|` are evaluated as JavaScript regex, not permission-rule syntax. `Bash(git commit*)` therefore never matched the bare tool name `Bash`, so the `check-arch-docs.sh` hook silently never ran. Moved the command filter to the documented `if` field while leaving the matcher as the bare tool name `Bash`. ([tools reference confirms hook matchers use bare tool names](https://code.claude.com/docs/en/tools-reference))
- **REQUIRED — MultiEdit tool removed.** MultiEdit no longer appears in the [official tools reference](https://code.claude.com/docs/en/tools-reference). Dropped it from the `PostToolUse` matcher (`Edit|Write|MultiEdit` → `Edit|Write`) and from the `allowed-tools` lists of the `python-refactor` and `refactor-code` skills.
- **REQUIRED — LS tool removed.** LS no longer appears in the [official tools reference](https://code.claude.com/docs/en/tools-reference) (Claude Code now uses `Glob` / `Bash ls` for directory listing). Dropped `LS(*)` from the `update-readme` skill's `allowed-tools`.

## Test plan

- [ ] `cat .claude/settings.json` and confirm the `git commit` hook block has `"matcher": "Bash"` with `"if": "Bash(git commit *)"` and that the `PostToolUse` matcher is `"Edit|Write"`.
- [ ] `grep -rn "MultiEdit\|LS(" .claude/` returns no matches.
- [ ] Run a `git commit` in a session and confirm `check-arch-docs.sh` actually fires (previously it never did because the regex `Bash(git commit*)` cannot match `Bash`).
- [ ] Run `/python-refactor`, `/refactor-code`, and `/update-readme` and confirm no permission prompts regress for `Edit`/`Glob`/`Read`/etc. that were previously also covered by `MultiEdit`/`LS`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVTyJBLNiyQqiuFcvZfXkB)_