### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,6 +113,7 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(rm *)",
             "command": "$HOME/.claude/hooks/validate-rm.sh",
             "timeout": 5
           }


### PR DESCRIPTION
## Summary

- RECOMMENDED (best practice): scope the `validate-rm.sh` `PreToolUse` hook with `if: "Bash(rm *)"` so it only spawns for `rm` invocations instead of every Bash call. Matches the canonical example in the docs and brings the entry in line with the existing `check-arch-docs` hook. Doc: https://code.claude.com/docs/en/hooks#filter-by-tool-name-and-arguments-with-the-if-field

No other actionable doc-driven changes were found this cycle. Skill frontmatter fields (`name`, `description`, `allowed-tools`, `disable-model-invocation`, `argument-hint`, `effort`), subagent frontmatter (`tools`, `model`, `color`), and `settings.json` keys in use are all current per the official references. Tool roster (Bash/Read/Edit/Write/Glob/Grep/etc.) checked against https://code.claude.com/docs/en/tools-reference; no removed tools remain.

## Test plan

- [ ] `jq . .claude/settings.json` succeeds (JSON is valid).
- [ ] In a new Claude Code session, run a non-`rm` Bash command and confirm `validate-rm.sh` is no longer invoked (no spawn cost per Bash call).
- [ ] Run a benign `rm` on a scratch file inside `.workspace/` and confirm the hook still runs.
- [ ] Run `rm -rf /` (or `rm -rf ~`) in Claude Code and confirm the hook still blocks it via the script's existing dangerous-pattern check.

---
_Generated by [Claude Code](https://claude.ai/code/session_016e2MPJ7NS9Ct8RwmKvh8oZ)_