### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,5 +1,4 @@
 ---
-description: Git 操作に関するルール
 paths:
   - "**/*"
 ---

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -1,5 +1,4 @@
 ---
-description: Markdown ファイル作成時のスタイルガイド
 paths:
   - "**/*.md"
 ---

--- a/.claude/rules/plan-files.md
+++ b/.claude/rules/plan-files.md
@@ -1,5 +1,4 @@
 ---
-description: プランファイル作成時のワークフロー
 paths:
   - "**/.claude/plans/*.md"
 ---

--- a/.claude/rules/workspace-management.md
+++ b/.claude/rules/workspace-management.md
@@ -1,5 +1,4 @@
 ---
-description: .workspace ディレクトリの運用ルール
 paths:
   - "**/*"
 ---


### PR DESCRIPTION
## Summary

- RECOMMENDED: Drop the undocumented `description` field from `.claude/rules/` frontmatter (`git-workflow.md`, `markdown-style.md`, `plan-files.md`, `workspace-management.md`). The official rule frontmatter schema documents only `paths`; `description` is silently ignored. This matches the established pattern from the earlier "drop undocumented settings keys" sync.
  - Doc: https://code.claude.com/docs/en/memory#path-specific-rules

Other areas inspected against the docs and confirmed already aligned (no changes needed):
- Settings keys, env vars (`CLAUDE_CODE_DISABLE_1M_CONTEXT`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, `CLAUDE_CODE_DISABLE_AUTO_MEMORY`, `CLAUDE_CODE_SUBAGENT_MODEL`, `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR`), permission `defaultMode: auto`, hook events (`PreToolUse`, `PostToolUse`, `Notification`, `Stop`), the `Bash` matcher with documented `if` field, `enabledPlugins` / `extraKnownMarketplaces`, skill / agent frontmatter fields in use (`disable-model-invocation`, `effort`, `argument-hint`, `tools`, `model: inherit`).
  - Docs cross-checked: https://code.claude.com/docs/en/settings, https://code.claude.com/docs/en/hooks, https://code.claude.com/docs/en/permissions, https://code.claude.com/docs/en/skills, https://code.claude.com/docs/en/sub-agents, https://code.claude.com/docs/en/env-vars, https://code.claude.com/docs/en/plugin-marketplaces

## Test plan

- [ ] `git diff main...HEAD` shows only the four `description:` lines removed.
- [ ] After checkout, `cat .claude/rules/git-workflow.md .claude/rules/markdown-style.md .claude/rules/plan-files.md .claude/rules/workspace-management.md` shows the `paths` field preserved and other content untouched.
- [ ] Start a Claude Code session in the repo, run `/memory`, and confirm all four rule files still appear in the loaded rules list (with their bodies intact and applied to matching paths).
- [ ] Trigger each rule's path scope (edit a `*.md` file for `markdown-style`, work under `.claude/plans/` for `plan-files`, any file for `git-workflow` / `workspace-management`) and confirm behavior is unchanged from `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQMNi1N4nThGige6ddhmsw)_