### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/hooks/check-arch-docs.sh
+++ b/.claude/hooks/check-arch-docs.sh
@@ -14,7 +14,10 @@ if [ -z "$STAGED_CODE" ]; then
 fi
 
 # block して Claude に自動判断を促す
-cat << 'EOF'
+# PreToolUse hook はブロック時に exit 2 + stderr を返す必要がある
+# （exit 1 は non-blocking error として扱われる）
+{
+  cat << 'EOF'
 BLOCK: docs/arch が存在するプロジェクトでコード変更を検出しました。
 
 【自動判断を実行してください】
@@ -31,14 +34,15 @@ BLOCK: docs/arch が存在するプロジェクトでコード変更を検出し
 - 更新不要: バグ修正(フロー変更なし)、リファクタ(振る舞い同一)、テスト追加
 EOF
 
-echo ""
-echo "変更対象のコードファイル:"
-echo "$STAGED_CODE" | sed 's/^/  - /'
-echo ""
-echo "変更の概要:"
-git diff --cached --stat
-echo ""
-echo "変更の詳細:"
-git diff --cached
+  echo ""
+  echo "変更対象のコードファイル:"
+  echo "$STAGED_CODE" | sed 's/^/  - /'
+  echo ""
+  echo "変更の概要:"
+  git diff --cached --stat
+  echo ""
+  echo "変更の詳細:"
+  git diff --cached
+} >&2
 
-exit 1
+exit 2

--- a/.claude/hooks/validate-rm.sh
+++ b/.claude/hooks/validate-rm.sh
@@ -47,12 +47,21 @@ DANGEROUS_PATTERNS=(
   'rm -fr .'
 )
 
+emit_deny() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+}
+
 for pattern in "${DANGEROUS_PATTERNS[@]}"; do
   # パターン直後が継続パス（./foo 等）にならないよう境界を確認
   if [[ "$COMMAND" == "$pattern" || "$COMMAND" == "$pattern "* || "$COMMAND" == "$pattern;"* || "$COMMAND" == "$pattern&"* || "$COMMAND" == "$pattern|"* ]]; then
-    cat <<EOF
-{"decision": "block", "reason": "危険な rm パターンを検出しました: $pattern"}
-EOF
+    emit_deny "危険な rm パターンを検出しました: $pattern"
     exit 0
   fi
 done
@@ -60,9 +69,7 @@ done
 # 追加チェック: 危険なパスへの再帰削除をブロックする
 # 末尾に $ や [[:space:]] を付けて、/Users/... のような安全なパスを誤検出しない
 if [[ "$COMMAND" =~ rm[[:space:]]+-[rf]+[[:space:]]+(/([[:space:]]|;|$)|\*|/\*|\$HOME|\$\{HOME\}|~|\.\.) ]]; then
-  cat <<EOF
-{"decision": "block", "reason": "危険なパスへの削除をブロックしました: ルート・ホーム・親ディレクトリへの再帰削除は許可されていません"}
-EOF
+  emit_deny "危険なパスへの削除をブロックしました: ルート・ホーム・親ディレクトリへの再帰削除は許可されていません"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Two PreToolUse hook scripts were emitting decisions in formats that the current Claude Code hooks spec does not honor, so dangerous `rm` patterns and `git commit` were not actually being blocked.

- **REQUIRED (breaking)**: `.claude/hooks/validate-rm.sh` now emits its deny decision under `hookSpecificOutput.permissionDecision` instead of the legacy top-level `{"decision": "block"}` payload. PreToolUse is documented to use only the `hookSpecificOutput` pattern; the top-level `decision` field is reserved for `UserPromptSubmit`/`PostToolUse`/`Stop`/etc. and is ignored for PreToolUse. https://code.claude.com/docs/en/hooks
- **REQUIRED (breaking)**: `.claude/hooks/check-arch-docs.sh` now exits with status 2 and writes its blocking message to stderr. Exit code 1 is documented as a non-blocking error for hooks, so the script's "BLOCK" intent was silently failing and the staged `git commit` was proceeding. https://code.claude.com/docs/en/hooks

## Test plan

- [ ] Manual: `echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | .claude/hooks/validate-rm.sh` returns the new `hookSpecificOutput` JSON with `permissionDecision: "deny"` and exits 0.
- [ ] Manual: `echo '{"tool_name":"Bash","tool_input":{"command":"rm /tmp/safe-file"}}' | .claude/hooks/validate-rm.sh` produces no output and exits 0.
- [ ] In a project with `docs/arch/` and a staged `*.ts` change, run a `git commit` through Claude Code and confirm the tool call is now actually blocked (Claude sees the BLOCK message and is forced to decide) rather than the commit proceeding.
- [ ] Run a `git commit` in a project without `docs/arch/` and confirm the hook still no-ops (early `exit 0`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUSYvfG72E1A48sf24yWiD)_