### PR TITLE
chore: sync Claude Code config with latest official docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,8 +103,7 @@
       "Bash(docker rmi *)",
       "Bash(npm publish *)",
       "Bash(gh pr merge *)"
-    ],
-    "defaultMode": "auto"
+    ]
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Summary

- REQUIRED (breaking): Drop `permissions.defaultMode: "auto"` from `.claude/settings.json`. Per the official [Claude Code settings docs](https://code.claude.com/docs/en/settings), as of v2.1.142 `auto` is ignored when set in project or local settings (to prevent repositories from granting themselves auto mode). The value silently does nothing today, so the file is cleaned up to reflect actual behavior. Auto mode can still be set at the user-level `~/.claude/settings.json`.

## Test plan

- [ ] `jq . .claude/settings.json` parses cleanly.
- [ ] Open Claude Code in this repo and run `/permissions` (or `/config`) — confirm the permission mode is no longer "auto" pinned by project settings and matches the user/global default mode.
- [ ] Confirm no regression in other behavior: hooks fire, allow/deny rules apply, plugins still load, `attribution` still suppresses commit/PR co-author lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASNbFtjTTDc5XKfcPRh5Zm)_