### PR TITLE
chore(markdown): enable MD036 and pin style rule in doc skills

### DIFF
--- a/.claude/skills/record-adr/SKILL.md
+++ b/.claude/skills/record-adr/SKILL.md
@@ -77,3 +77,4 @@ allowed-tools: Read(*), Glob(*), Grep(*), Write(*), Edit(*), Bash(ls:*), Bash(gr
 5. 実験の生ログ・試行錯誤は `.workspace/knowledge/`、確定した決定と根拠は docs/adr
 6. 採番が衝突した場合(並行ブランチ等)は後から追加した方を繰り上げる
 7. 本文段落はハードラップしない。1 段落を 1 行で書く。エディタの折り返し表示に委ねる
+8. Markdown スタイルは `~/.claude/rules/markdown-style.md` に従う。

--- a/.claude/skills/update-arch/SKILL.md
+++ b/.claude/skills/update-arch/SKILL.md
@@ -200,3 +200,4 @@ Claude Code 使用時は自動で更新判断が行われます。
 3. ファイル参照は `file_path:line_number` 形式で記載する
 4. 更新不要と判断した場合は理由を明確に説明する
 5. 過度に詳細な文書化は避け、理解に必要な粒度を維持する
+6. Markdown スタイルは `~/.claude/rules/markdown-style.md` に従う。

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -62,3 +62,4 @@ allowed-tools: Read(*), Glob(*), Grep(*), Write(*), Bash(find:*), Bash(head:*), 
 - 絵文字はできる限り使用しない
 - 強調（太字）の使用を最小限にする
 - トラブルシューティングや FAQ セクションは含めない
+- Markdown スタイルは `~/.claude/rules/markdown-style.md` に従う。

--- a/.config/markdown-cli2/.markdownlint-cli2.jsonc
+++ b/.config/markdown-cli2/.markdownlint-cli2.jsonc
@@ -20,6 +20,9 @@
     "MD048": { "style": "backtick" },
 
     // Disable table column alignment check for CJK content
-    "MD060": false
+    "MD060": false,
+
+    // Disallow emphasis (**bold** / *italic*) used as a pseudo-heading
+    "MD036": true
   }
 }


### PR DESCRIPTION
## Summary

- Enable markdownlint MD036 (no-emphasis-as-heading) in `.markdownlint-cli2.jsonc`
- Reference `~/.claude/rules/markdown-style.md` from record-adr, update-arch, update-readme skills so the rule stays salient during skill execution

## Test plan

- `markdownlint-cli2` picks up the new MD036 setting (existing files already pass)
- Invoke `/record-adr`, `/update-arch`, `/update-readme` and confirm generated docs avoid bold-as-heading