### PR TITLE
fix(skills): prevent skill load crash outside git repositories

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,7 @@
     "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet",
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "70"
+    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
   },
   "attribution": {
     "commit": "",
@@ -107,7 +106,6 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "claude-opus-4-7",
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/cleanup-files/SKILL.md
+++ b/.claude/skills/cleanup-files/SKILL.md
@@ -11,7 +11,7 @@ Clean up experiment workspace and scan/remove unnecessary files project-wide bas
 
 ## Current state
 
-- Git status: !`git status --short`
+- Git status: !`git status --short 2>/dev/null || true`
 - Workspace experiments: !`ls .workspace/experiments/ 2>/dev/null || true`
 - Workspace analysis: !`ls .workspace/analysis/ 2>/dev/null || true`
 

--- a/.claude/skills/execute-plan/SKILL.md
+++ b/.claude/skills/execute-plan/SKILL.md
@@ -31,8 +31,8 @@ argument-hint: "[plan-file-path]"
 
 ## Current state
 
-- Branch: !`git rev-parse --abbrev-ref HEAD`
-- Uncommitted changes: !`git status --porcelain | head -20`
+- Branch: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "(not a git repository)"`
+- Uncommitted changes: !`git status --porcelain 2>/dev/null | head -20`
 - Available plans: !`ls -1t .claude/plans/ 2>/dev/null | head -10 || echo "no plans"`
 
 ## コア原則

--- a/.claude/skills/refactor-code/SKILL.md
+++ b/.claude/skills/refactor-code/SKILL.md
@@ -14,7 +14,7 @@ If a target path is specified via arguments (`$ARGUMENTS`), scope the refactorin
 
 ## Current state
 
-- Git status: !`git status --short`
+- Git status: !`git status --short 2>/dev/null || true`
 - Project type: !`ls pyproject.toml package.json Cargo.toml go.mod 2>/dev/null || true`
 
 ## Refactoring Procedure


### PR DESCRIPTION
## Summary

- Harden `!`-prefixed inline shell commands in skill `## Current state` sections so loading a skill outside a git repository no longer aborts with a fatal error (execute-plan, cleanup-files, refactor-code)
- Drop the `model` override and `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` from `.claude/settings.json`

## Test plan

- Outside a git repo (`cd /`): hardened commands exit 0; branch falls back to `(not a git repository)`
- Inside the repo: `git status` / `git rev-parse` output unchanged (no regression)
- Manually load `/execute-plan`, `/cleanup-files`, `/refactor-code` from a non-git directory and confirm no load error
