### PR TITLE
chore(settings): drop pinned model to use default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -207,6 +207,5 @@
   "plansDirectory": ".claude/plans",
   "autoMemoryEnabled": false,
   "skipWorkflowUsageWarning": true,
-  "editorMode": "vim",
-  "model": "claude-opus-4-7"
+  "editorMode": "vim"
 }


### PR DESCRIPTION
## Summary

- `.claude/settings.json` から `"model": "claude-opus-4-7"` の固定指定を削除し、デフォルトモデルを使用するように変更

## Test plan

- Claude Code 起動時にデフォルトモデルが選択されることを確認
