### PR TITLE
chore(settings): drop overrides and lower effort to high

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
-    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1"
   },
   "attribution": {
     "commit": "",
@@ -197,13 +194,12 @@
       }
     }
   },
-  "viewMode": "verbose",
   "language": "japanese",
   "sandbox": {
     "enabled": false
   },
   "alwaysThinkingEnabled": true,
-  "effortLevel": "xhigh",
+  "effortLevel": "high",
   "plansDirectory": ".claude/plans",
   "autoMemoryEnabled": false,
   "skipWorkflowUsageWarning": true,


### PR DESCRIPTION
## Summary

- Remove env overrides: 1M context disable, auto-compact window, subagent model pin
- Remove `viewMode: verbose` override
- Lower `effortLevel` from xhigh to high

## Test plan

- Settings-only change; verified `.claude/settings.json` remains valid JSON
